### PR TITLE
Add a simple port example

### DIFF
--- a/examples/port.py
+++ b/examples/port.py
@@ -4,33 +4,33 @@
 import erlang, os, struct
 
 def send(term, stream):
-  """Write an Erlang term to an output stream."""
-  payload = erlang.term_to_binary(term)
-  header = struct.pack('!I', len(payload))
-  stream.write(header)
-  stream.write(payload)
-  stream.flush()
+    """Write an Erlang term to an output stream."""
+    payload = erlang.term_to_binary(term)
+    header = struct.pack('!I', len(payload))
+    stream.write(header)
+    stream.write(payload)
+    stream.flush()
 
 def recv(stream):
-  """Read an Erlang term from an input stream."""
-  header = stream.read(4)
-  if len(header) != 4:
-    return None # EOF
-  (length,) = struct.unpack('!I', header)
-  payload = stream.read(length)
-  if len(payload) != length:
-    return None
-  term = erlang.binary_to_term(payload)
-  return term
+    """Read an Erlang term from an input stream."""
+    header = stream.read(4)
+    if len(header) != 4:
+        return None # EOF
+    (length,) = struct.unpack('!I', header)
+    payload = stream.read(length)
+    if len(payload) != length:
+        return None
+    term = erlang.binary_to_term(payload)
+    return term
 
 def recv_loop(stream):
-  """Yield Erlang terms from an input stream."""
-  message = recv(stream)
-  while message:
-    yield message
+    """Yield Erlang terms from an input stream."""
     message = recv(stream)
+    while message:
+        yield message
+        message = recv(stream)
 
 if __name__ == '__main__':
-  input, output = os.fdopen(3, 'rb'), os.fdopen(4, 'wb')
-  for message in recv_loop(input):
-    send(message, output)
+    input, output = os.fdopen(3, 'rb'), os.fdopen(4, 'wb')
+    for message in recv_loop(input):
+        send(message, output) # echo the message back

--- a/examples/port.py
+++ b/examples/port.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# This is free and unencumbered software released into the public domain.
+
+import erlang, struct, sys, traceback
+
+# Ensure compatibility with Python 2.x and 3.x both:
+if sys.version_info >= (3, 0):
+  sys.stdin  = sys.stdin.buffer
+  sys.stdout = sys.stdout.buffer
+
+def send(term, stream=sys.stdout):
+  """Write an Erlang term to an output stream."""
+  payload = erlang.term_to_binary(term)
+  header = struct.pack('!I', len(payload))
+  stream.write(header)
+  stream.write(payload)
+
+def recv(stream=sys.stdin):
+  """Read an Erlang term from an input stream."""
+  header = stream.read(4)
+  if len(header) != 4:
+    return None # EOF
+  (length,) = struct.unpack('!I', header)
+  payload = stream.read(length)
+  if len(payload) != length:
+    return None
+  term = erlang.binary_to_term(payload)
+  return term
+
+def recv_loop(stream=sys.stdin):
+  """Yield Erlang terms from an input stream."""
+  message = recv(stream=stream)
+  while message:
+    yield message
+    message = recv(stream=stream)
+
+if __name__ == '__main__':
+  try:
+    for message in recv_loop():
+      send(message)
+  except:
+    send(traceback.format_exc())

--- a/examples/test.exs
+++ b/examples/test.exs
@@ -2,7 +2,7 @@
 # This is free and unencumbered software released into the public domain.
 
 port = Port.open({:spawn_executable, "/usr/bin/env"},
-  [:binary, {:packet, 4}, {:args, ["python", "-u", "port.py"]}])
+  [:binary, {:packet, 4}, {:args, ["python", "-u", "port.py"]}, :nouse_stdio])
 
 defmodule Python do
   def call(port, request) do

--- a/examples/test.exs
+++ b/examples/test.exs
@@ -1,0 +1,18 @@
+#!/usr/bin/env elixir
+# This is free and unencumbered software released into the public domain.
+
+port = Port.open({:spawn_executable, "/usr/bin/env"},
+  [:binary, {:packet, 4}, {:args, ["python", "-u", "port.py"]}])
+
+defmodule Python do
+  def call(port, request) do
+    Port.command(port, :erlang.term_to_binary(request))
+    receive do
+      {^port, {:data, response}} -> :erlang.binary_to_term(response)
+    end
+  end
+end
+
+IO.inspect Python.call(port, {:ping})
+
+Port.close(port)


### PR DESCRIPTION
This pull request adds a basic example of interprocess communication between Elixir and Python scripts using an Erlang port and the Erlang external term format.

Running `examples/test.exs` will spawn `examples/port.py` as a port subprocess that will echo back any Erlang term sent to the port, in the `examples/test.exs` example the single-atom tuple `{ping}`.