### PR TITLE
Fix byte to integer conversion

### DIFF
--- a/erlang.py
+++ b/erlang.py
@@ -603,7 +603,7 @@ def _binary_to_term(i, data):
         )
         return (i + j, OtpErlangAtom(atom_name))
     elif tag == _TAG_SMALL_ATOM_UTF8_EXT:
-        j = b_ord(data[i:i + 1])
+        j = b_ord(data[i])
         i += 1
         atom_name = TypeUnicode(
             data[i:i + j], encoding='utf-8', errors='strict'

--- a/tests/erlang_tests.py
+++ b/tests/erlang_tests.py
@@ -128,6 +128,8 @@ class DecodeTestCase(unittest.TestCase):
                          erlang.binary_to_term(b'\x83d\0\4test'))
         self.assertEqual(erlang.OtpErlangAtom(b'test'),
                          erlang.binary_to_term(b'\x83s\4test'))
+        self.assertEqual(erlang.OtpErlangAtom(u'name'),
+                         erlang.binary_to_term(b'\x83w\x04name'))
     def test_binary_to_term_predefined_atoms(self):
         self.assertEqual(True, erlang.binary_to_term(b'\x83s\4true'))
         self.assertEqual(False, erlang.binary_to_term(b'\x83s\5false'))


### PR DESCRIPTION
Code was raising exception when:

```
Python 3.7.2 (default, Feb 12 2019, 08:16:38)
[Clang 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import erlang
>>> from base64 import b64decode
>>> print(erlang.binary_to_term(b64decode('g3cEbmFtZQ==')))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/thales/projects/erlang_py/erlang.py", line 421, in binary_to_term
    i, term = _binary_to_term(1, data)
  File "/Users/thales/projects/erlang_py/erlang.py", line 609, in _binary_to_term
    data[i:i + j], encoding='utf-8', errors='strict'
TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
```