### PR TITLE
Fix list in a tuple of a map key causing hashable error

### DIFF
--- a/erlang.py
+++ b/erlang.py
@@ -604,15 +604,19 @@ def _binary_to_term(i, data):
         length = struct.unpack(b'>I', data[i:i + 4])[0]
         i += 4
         pairs = {}
+        def to_immutable(value):
+            if isinstance(value, dict):
+                return frozendict(key)
+            elif isinstance(value, list):
+                return OtpErlangList(value)
+            elif isinstance(value, tuple):
+                return tuple(to_immutable(v) for v in value)
+            return value
+
         for _ in range(length):
             i, key = _binary_to_term(i, data)
             i, value = _binary_to_term(i, data)
-            if isinstance(key, dict):
-                pairs[frozendict(key)] = value
-            elif isinstance(key, list):
-                pairs[OtpErlangList(key)] = value
-            else:
-                pairs[key] = value
+            pairs[to_immutable(key)] = value
         return (i, pairs)
     if tag == _TAG_FUN_EXT:
         old_i = i

--- a/tests/erlang_tests.py
+++ b/tests/erlang_tests.py
@@ -169,6 +169,11 @@ class DecodeTestCase(unittest.TestCase):
         self.assertEqual(isinstance(lst, erlang.OtpErlangList), True)
         self.assertEqual([[], erlang.OtpErlangAtom(b'tail')], lst.value)
         self.assertEqual(True, lst.improper)
+    def test_binary_to_term_map(self):
+        # represents #{ {at,[hello]} => ok}
+        binary = b"\x83t\x00\x00\x00\x01h\x02d\x00\x02atl\x00\x00\x00\x01d\x00\x05hellojd\x00\x02ok"
+        map_with_list = erlang.binary_to_term(binary)
+        self.assertEqual(isinstance(map_with_list, dict), True)
     def test_binary_to_term_small_tuple(self):
         self.assertRaises(erlang.ParseException,
                           erlang.binary_to_term, b'\x83h')


### PR DESCRIPTION
This is an attempt to fix

```
  File "erlang.py", line 615, in _binary_to_term
    pairs[key] = value
TypeError: unhashable type: 'list'
```
I also added a test case with an example where this happened